### PR TITLE
Add ESP32 macropad firmware and configurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# keypad
+# ESP32 Adjustable Macropad
+
+This project provides a basic firmware sketch for an ESP32 based macropad and a simple Windows configurator.
+
+## Firmware
+
+The Arduino sketch is located in `firmware/keypad.ino`. It implements:
+
+- Configurable key matrix size.
+- USB HID keyboard output.
+- "Burner" mode for updating key mappings. Hold the burner pin (`GPIO0` by default) low at boot and send a JSON mapping over serial.
+
+Example mapping JSON:
+
+```json
+{
+  "keys": [["A", "B", "C"], ["Ctrl+Alt+Delete", "Enter", "Hello"], ["1", "2", "3"]]
+}
+```
+
+The JSON is stored in flash using the `Preferences` library.
+
+## Windows Configurator
+
+`windows_configurator.py` is a small `tkinter` GUI for sending mapping JSON files to the board. Install `pyserial` and run the script or build an executable using PyInstaller:
+
+```bash
+pip install pyserial
+pyinstaller --onefile windows_configurator.py
+```
+
+Select the serial port, load a JSON mapping, and send it to the device while it is in burner mode.

--- a/firmware/keypad.ino
+++ b/firmware/keypad.ino
@@ -1,0 +1,113 @@
+#include <Arduino.h>
+#include <Preferences.h>
+#include <ArduinoJson.h>
+#include <USB.h>
+
+// Configurable matrix size
+#ifndef NUM_ROWS
+#define NUM_ROWS 3
+#endif
+#ifndef NUM_COLS
+#define NUM_COLS 3
+#endif
+
+// GPIO pins for rows and cols (example pins)
+const uint8_t rowPins[NUM_ROWS] = {2, 3, 4};
+const uint8_t colPins[NUM_COLS] = {5, 6, 7};
+
+// Burner pin (held LOW on boot to enter burner mode)
+const uint8_t BURNER_PIN = 0;
+
+Preferences prefs;
+
+String keyMap[NUM_ROWS][NUM_COLS];
+
+void saveMapping(const String &json) {
+  prefs.begin("keypad", false);
+  prefs.putString("mapping", json);
+  prefs.end();
+}
+
+void loadMapping() {
+  prefs.begin("keypad", true);
+  String json = prefs.getString("mapping", "{}");
+  prefs.end();
+  if (json.length() == 0) return;
+
+  StaticJsonDocument<1024> doc;
+  if (deserializeJson(doc, json) == DeserializationError::Ok) {
+    JsonArray keys = doc["keys"].as<JsonArray>();
+    for (int r = 0; r < NUM_ROWS; r++) {
+      for (int c = 0; c < NUM_COLS; c++) {
+        keyMap[r][c] = keys[r][c].as<String>();
+      }
+    }
+  }
+}
+
+void sendMacro(const String &macro) {
+  if (macro.indexOf('+') != -1) {
+    // Modifier combination
+    String temp = macro;
+    temp.replace("+", " ");
+    // parse tokens
+    std::vector<String> parts;
+    char *token = strtok((char*)temp.c_str(), " ");
+    while (token) {
+      parts.push_back(String(token));
+      token = strtok(NULL, " ");
+    }
+    for (size_t i = 0; i < parts.size(); i++) {
+      Keyboard.press(parts[i][0]); // simplistic
+    }
+    Keyboard.releaseAll();
+  } else {
+    Keyboard.print(macro);
+  }
+}
+
+void scanMatrix() {
+  for (int r = 0; r < NUM_ROWS; r++) {
+    digitalWrite(rowPins[r], LOW);
+    for (int c = 0; c < NUM_COLS; c++) {
+      if (digitalRead(colPins[c]) == LOW) {
+        sendMacro(keyMap[r][c]);
+        delay(200);
+      }
+    }
+    digitalWrite(rowPins[r], HIGH);
+  }
+}
+
+void burnerMode() {
+  Serial.println("Entering burner mode. Send JSON mapping...");
+  String json = Serial.readStringUntil('\n');
+  saveMapping(json);
+  Serial.println("Mapping saved. Reboot device.");
+  while (1) {
+    delay(1000);
+  }
+}
+
+void setup() {
+  pinMode(BURNER_PIN, INPUT_PULLUP);
+  if (digitalRead(BURNER_PIN) == LOW) {
+    Serial.begin(115200);
+    while (!Serial) {}
+    burnerMode();
+  }
+
+  for (int r = 0; r < NUM_ROWS; r++) {
+    pinMode(rowPins[r], OUTPUT);
+    digitalWrite(rowPins[r], HIGH);
+  }
+  for (int c = 0; c < NUM_COLS; c++) {
+    pinMode(colPins[c], INPUT_PULLUP);
+  }
+  loadMapping();
+  USB.begin();
+}
+
+void loop() {
+  scanMatrix();
+}

--- a/windows_configurator.py
+++ b/windows_configurator.py
@@ -1,0 +1,45 @@
+import json
+import serial
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+class Configurator(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("ESP32 Macropad Configurator")
+        self.geometry("400x300")
+        tk.Label(self, text="Serial Port:").pack()
+        self.port_entry = tk.Entry(self)
+        self.port_entry.pack()
+        tk.Button(self, text="Load JSON", command=self.load_json).pack()
+        tk.Button(self, text="Send to Device", command=self.send).pack()
+        self.text = tk.Text(self)
+        self.text.pack(expand=True, fill="both")
+        self.json_data = None
+
+    def load_json(self):
+        path = filedialog.askopenfilename(filetypes=[("JSON", "*.json")])
+        if not path:
+            return
+        with open(path, 'r') as f:
+            self.json_data = f.read()
+        self.text.delete('1.0', tk.END)
+        self.text.insert(tk.END, self.json_data)
+
+    def send(self):
+        if not self.json_data:
+            self.json_data = self.text.get('1.0', tk.END)
+        port = self.port_entry.get()
+        if not port:
+            messagebox.showerror("Error", "Specify serial port")
+            return
+        try:
+            with serial.Serial(port, 115200, timeout=3) as ser:
+                ser.write(self.json_data.encode('utf-8') + b'\n')
+            messagebox.showinfo("Done", "Mapping sent")
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
+if __name__ == "__main__":
+    app = Configurator()
+    app.mainloop()


### PR DESCRIPTION
## Summary
- add adjustable macropad firmware for ESP32 with burner mode
- add Windows Python configurator GUI
- document setup instructions

## Testing
- `python windows_configurator.py --help` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6848d8a032e8832390749795fbd261c5